### PR TITLE
fix: Correcting template syntax

### DIFF
--- a/app/templates/header.html
+++ b/app/templates/header.html
@@ -8,3 +8,4 @@
     </div>
   </div>
 </header>
+{% endblock %}


### PR DESCRIPTION
- Reversing an error during merging: template must have {%endblock}