### PR TITLE
capslock unit code in forms

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -77,7 +77,7 @@ def review():
             return redirect(url_for('add_unit'))
         dataEntry = DiaryEntry(
             user_email='test', #To replace with current_user.email
-            unit_id=form.rev_code.data,
+            unit_id=form.rev_code.data.upper(), #capslocks unit code before adding to database
             semester=form.rev_semester.data,
             year=form.rev_year.data,
             grade=form.rev_grade.data,
@@ -103,7 +103,7 @@ def add_unit():
             db.session.add(faculty)
             db.session.commit()
         unit = Unit(
-            code=form.add_code.data,
+            code=form.add_code.data.upper(), #capslocks unit code before adding to database
             title=form.add_unit_name.data,
             faculty_id=form.add_faculty.data,
             level=form.add_unit_level.data,

--- a/app/templates/add_unit.html
+++ b/app/templates/add_unit.html
@@ -4,9 +4,9 @@
     <h2>Add a Unit</h2>
     <form action="" method="post">
         {{form.hidden_tag()}}
-        <p>{{form.add_uni.label}} {{form.add_uni}}</p>
+        <p>{{form.add_uni.label}}<br>{{form.add_uni}}</p>
         <p>{{form.add_faculty.label}}<br>{{form.add_faculty}}</p>
-        <p>{{form.add_code.label}} {{form.add_code}}</p>
+        <p>{{form.add_code.label}}<br>{{form.add_code(style="text-transform: uppercase;")}}</p> <!--capslocks inputted unit code (frontend only)-->
         <p>{{form.add_unit_name.label}}<br>{{form.add_unit_name}}</p>
         <p>{{form.add_unit_level.label}}<br>{{form.add_unit_level}}</p>
         <p>{{form.add_submit.label}}<br>{{form.add_submit}}</p>

--- a/app/templates/unit_review.html
+++ b/app/templates/unit_review.html
@@ -6,7 +6,7 @@
         {{form.hidden_tag()}}
         <p>{{form.rev_uni.label}} {{form.rev_uni}}</p>
         <p>{{form.rev_semester.label}} {{form.rev_semester}}</p>
-        <p>{{form.rev_code.label}} {{form.rev_code}}</p>
+        <p>{{form.rev_code.label}} {{form.rev_code(style="text-transform: uppercase;")}}</p> <!--capslocks inputted unit code (frontend only)-->
         <p>{{form.rev_year.label}} {{form.rev_year}}</p>
         <p>{{form.rev_unit_coord_rating.label}}<br>{{form.rev_unit_coord_rating}}</p>
         <p>{{form.rev_difficulty.label}}<br>{{form.rev_difficulty}}</p>


### PR DESCRIPTION
when users input the unit code it will automatically be in uppercase, both on the form and when added to the db - helps avoid adding the same unit twice